### PR TITLE
do not mark non-required library sections as required

### DIFF
--- a/GenerateSwoop.py
+++ b/GenerateSwoop.py
@@ -413,10 +413,10 @@ tags["note"] = TagClass("note",
 tags["library"] = TagClass("library",
                            baseclass = "EagleFilePart",
                            attrs=[Attr("name", required=False)],
-                           sections=[Singleton("description", "./description", requireTag=True),
-                                     Map("packages", "./packages/package", requireTag=True),
-                                     Map("symbols", "./symbols/symbol" , requireTag=True),
-                                     Map("devicesets", "./devicesets/deviceset", requireTag=True)])
+                           sections=[Singleton("description", "./description", requireTag=False),
+                                     Map("packages", "./packages/package", requireTag=False),
+                                     Map("symbols", "./symbols/symbol" , requireTag=False),
+                                     Map("devicesets", "./devicesets/deviceset", requireTag=False)])
 
 tags["schematic"] = TagClass("schematic",
                              baseclass = "EagleFilePart",


### PR DESCRIPTION
From the DTD:

    <!ELEMENT library (description?, packages?, symbols?, devicesets?)>

None of these sections are requried, if they are empty, Swoop would generate
`<symbols/>` (or whichever) tags inside `library`s which Eagle would then
delete the next time it opened the file

As an example of a library with no symbols or devicesets, we have a library
that has premade logos for dropping on to boards