### PR TITLE
change lxml 3.6.2 -> 4.3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(name='Swoop',
           "Swoop" : ["Swoop/Swoop.py.jinja", "Swoop/eagle.dtd.diff", "Swoop/*.dtd", "Swoop/default.dru"]
       },
       #ext_modules = cythonize([Extension("*", ["Swoop/Swoop.pyx"], extra_compile_args=["-O4"])]),
-      install_requires=["lxml==3.6.2",  "Sphinx>=1.3.1","Jinja2>=2.7.3", "shapely>=1.5.13"],
+      install_requires=["lxml==4.3.2",  "Sphinx>=1.3.1","Jinja2>=2.7.3", "shapely>=1.5.13"],
       setup_requires=["Jinja2>=2.7.3"],#, "lxml>=3.4.2"],
       include_package_data=True,
       entry_points={


### PR DESCRIPTION
3.6.2 is very difficult to install. It requires a few libraries etc...

4.3.2 install easily with pip.

This should fix one of the issues (Error with lxml==3.6.2 in setup.py #10).

Seems like all the unittests work except one geo check with Shapely. I don't know if this also is the case in the current master because I can't install it.