### PR TITLE
Fix DRU import error when installing with PIP

### DIFF
--- a/Swoop/__init__.py
+++ b/Swoop/__init__.py
@@ -1,3 +1,6 @@
 from Swoop import *
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))
 from DRU import *
 


### PR DESCRIPTION
When installing with PIP the python did not found the DRU.py when parsed the __init__.py since the folder contaning it is not part of the PYTHONPATH.
I am not a python expert, so I do not know how elegant this solution, but it should be working.
Fixes #9

