### PR TITLE
Correct the following 2 error message, when the default.dru ist used (0.65)

### DIFF
--- a/Swoop/DRU.py
+++ b/Swoop/DRU.py
@@ -27,7 +27,13 @@ class DRUFile():
         """
 
         for l in stream.readlines():
-            m = re.match("^(\w+)(\[(\w+)\])? = (.*)$", l);
+            try:
+                m = re.match("^(\w+)(\[(\w+)\])? = (.*)$", l);
+            except TypeError:
+                l = l.decode('utf8')
+                m = re.match("^(\w+)(\[(\w+)\])? = (.*)$", l);
+            except:
+                raise
             assert m is not None, "Unexpected line format in '{}': {}".format(filename,l)
             key = m.group(1)
             dictkey = m.group(3)
@@ -39,7 +45,7 @@ class DRUFile():
             else:
                 values = value.split(" ")
                 for i in range(0, len(values)):
-                    m = re.match("^(-?\d+(\.\d+)?)(\w+)?$", values[i]);
+                    m = re.match("^(-?\d+(\.\d+)?)(\w+)?\r?$", values[i]);
                     assert m is not None, "Unknown value format in '{}': {}".format(filename,values[i])
                     n = m.group(1)
                     units = m.group(3)


### PR DESCRIPTION
I use Win 10 and I loaded a library in python 3.7. I got two error messages:

###  Error message 1:

```
   File "d:/swoop-06.5/test_library_technologies.py", line 49, in add_lbr
    lbrf = Swoop.EagleFile.from_file(file)

  File "c:\program files\python37\lib\site-packages\swoop-0.6.5-py3.7.egg\Swoop\Swoop.py", line 1224, in from_file
    n = cls.from_stream(cls.get_library_file_type(), f, bestEffort, DRUFile, pickle, filename=filename)

  File "c:\program files\python37\lib\site-packages\swoop-0.6.5-py3.7.egg\Swoop\Swoop.py", line 1184, in from_stream
    ef.DRUFile = DRU.DRUFile(s)

  File "c:\program files\python37\lib\site-packages\swoop-0.6.5-py3.7.egg\Swoop\DRU.py", line 20, in __init__
    self.open(stream, filename=filename);

  File "c:\program files\python37\lib\site-packages\swoop-0.6.5-py3.7.egg\Swoop\DRU.py", line 30, in open
    m = re.match("^(\w+)(\[(\w+)\])? = (.*)$", l);

  File "c:\program files\python37\lib\re.py", line 173, in match
    return _compile(pattern, flags).match(string)

TypeError: cannot use a string pattern on a bytes-like object`
```

_Solution:_ Decode the file
### Error message 2:
```
  File "c:\program files\python37\lib\site-packages\swoop-0.6.5-py3.7.egg\Swoop\DRU.py", line 51, in open
    assert m is not None, "Unknown value format in '{}': {}".format(filename,values[i])

AssertionError: Unknown value format in 'None': 0.035mm
```

_Solution:_
default.dru is encoded with windows lf. \r is not detected (this error just occurs on the last value in the line.
Quelle: [stackoverflow: $ Windows newline symbol in Python bytes regex](https://stackoverflow.com/questions/31399999/windows-newline-symbol-in-python-bytes-regex):

> Note that $ matches \n but does not match \r\n (the combination of carriage return and newline characters, or CR/LF). To match the CR/LF character combination, include \r?$ in the regular expression pattern.