### PR TITLE
Decode unicode before regex parsing

### DIFF
--- a/Swoop/DRU.py
+++ b/Swoop/DRU.py
@@ -26,7 +26,7 @@ class DRUFile():
         :param stream: File-like object to load.
         """
 
-        for l in stream.readlines():
+        for l in map(lambda lu: lu.decode('utf-8'), stream.readlines()):
             m = re.match("^(\w+)(\[(\w+)\])? = (.*)$", l);
             assert m is not None, "Unexpected line format in '{}': {}".format(filename,l)
             key = m.group(1)


### PR DESCRIPTION
The XML library requires bytes rather than strings, so leave the file
opening as binary. However, the regex needs a string to operate on, so
let's fix that.

Fixes #15.