### PR TITLE
Update DTD for Eagle 9.6.2

### DIFF
--- a/Swoop/Swoop.py.jinja
+++ b/Swoop/Swoop.py.jinja
@@ -896,6 +896,7 @@ supportedVersions = {
             (9,3,5):"eagle-9.2.2.patched.dtd",
             (9,3,6):"eagle-9.2.2.patched.dtd",
             (9,3,7):"eagle-9.2.2.patched.dtd",
+            (9,6,2):"eagle-9.6.2.patched.dtd",
         }
         
     

--- a/Swoop/eagle-9.6.2.dtd
+++ b/Swoop/eagle-9.6.2.dtd
@@ -1,0 +1,741 @@
+<!--
+  EAGLE version $__VersionNumber__ DTD
+  Copyright (c) $__ThisYear__ Autodesk
+  http://www.autodesk.com
+
+  This file describes the XML file format used by EAGLE version $__VersionNumber__,
+  hereafter referred to as the "EAGLE File Format".
+  It is made available under the creative commons "CC BY-ND 3.0" license
+  (see http://creativecommons.org/licenses/by-nd/3.0).
+  You may use this file to implement a program that reads and/or writes files
+  in the EAGLE File Format. If your program writes files in the EAGLE File
+  Format, these files must be readable by EAGLE version $__VersionNumber__
+  without any error messages or warnings.
+-->
+
+<!-- ### Entity definitions ############################################### -->
+
+<!ENTITY % Int               "CDATA"> <!-- an integer number -->
+<!ENTITY % Real              "CDATA"> <!-- a real number -->
+<!ENTITY % String            "CDATA"> <!-- a character string -->
+<!ENTITY % Bool              "(no | yes)">
+<!ENTITY % Coord             "%Real;"> <!-- coordinates, given in millimeters -->
+<!ENTITY % Dimension         "%Real;"> <!-- dimensions, given in millimeters -->
+<!ENTITY % Layer             "%Int;"> <!-- layer number -->
+<!ENTITY % GridUnit          "(mic | mm | mil | inch)">
+<!ENTITY % GridStyle         "(lines | dots)">
+<!ENTITY % WireStyle         "(continuous | longdash | shortdash | dashdot)">
+<!ENTITY % WireCap           "(flat | round)">
+<!ENTITY % WireCurve         "%Real;"> <!-- curvature of a wire; allowed range: -359.9..359.9 -->
+<!ENTITY % Class             "%Int;"> <!-- net class -->
+<!ENTITY % PadShape          "(square | round | octagon | long | offset)">
+<!ENTITY % ViaShape          "(square | round | octagon)">
+<!ENTITY % TextFont          "(vector | proportional | fixed)">
+<!ENTITY % Rotation          "CDATA"> <!-- rotation of an object; allowed range: [MSR]0..359.9 -->
+<!ENTITY % AttributeDisplay  "(off | value | name | both)">
+<!ENTITY % Extent            "%String;"> <!-- the layers a via or airwire extends through, given as "topmost-bottommost" -->
+<!ENTITY % PolygonPour       "(solid | hatch | cutout)">
+<!ENTITY % PinVisible        "(off | pad | pin | both)">
+<!ENTITY % PinLength         "(point | short | middle | long)">
+<!ENTITY % PinDirection      "(nc | in | out | io | oc | pwr | pas | hiz | sup)">
+<!ENTITY % PinFunction       "(none | dot | clk | dotclk)">
+<!ENTITY % PortDirection     "(nc | in | out | io | oc | pwr | pas | hiz)">
+<!ENTITY % GateAddLevel      "(must | can | next | request | always)">
+<!ENTITY % ContactRoute      "(all | any)">
+<!ENTITY % DimensionType     "(parallel | horizontal | vertical | radius | diameter | angle | leader)">
+<!ENTITY % Package3dType     "(model | box)">
+<!ENTITY % Severity          "(info | warning | error)">
+<!ENTITY % Align             "(bottom-left | bottom-center | bottom-right | center-left | center | center-right | top-left | top-center | top-right)">
+<!ENTITY % VerticalText      "(up | down)">
+<!ENTITY % Urn               "%String;"> <!-- of the form "urn:adsk.eagle:<ASSET_TYPE>:<ASSET_ID>/<VERSION>", where:
+                                              - <ASSET_TYPE> is "symbol", "footprint", "package", "component", or "library"
+                                              - <ASSET_ID> is an integer
+                                              - <VERSION> is an integer
+                                              The "/<VERSION>" is omitted when referencing the asset without specifying a particular version.
+                                              For example, "urn:adsk.eagle:component:60986/2" references version 2 of component 60986 and
+                                              "urn:adsk.eagle:library:60968" references library 60986 without specifying a version. -->
+
+<!-- ### Drawing definitions ############################################## -->
+
+<!ELEMENT eagle (compatibility?, drawing, compatibility?)>
+<!ATTLIST eagle
+          version       %Real;         #REQUIRED
+          >
+          <!-- version: The EAGLE program version that generated this file, in the form V.RR -->
+
+<!ELEMENT compatibility (note)*>
+
+<!ELEMENT note (#PCDATA)>
+<!ATTLIST note
+          version       %Real;         #REQUIRED
+          severity      %Severity;     #REQUIRED
+          >
+          <!-- version: The EAGLE program version that introduced this compatibility note -->
+
+<!ELEMENT drawing (settings?, grid?, filters?, layers, (library | schematic | board))>
+
+<!ELEMENT library (description?, packages?, packages3d?, symbols?, devicesets?)>
+<!ATTLIST library
+          name          %String;       #REQUIRED
+          urn           %Urn;          ""
+          >
+          <!-- name: Only in libraries used inside boards or schematics -->
+          <!-- urn: Only in online libraries used inside boards or schematics -->
+
+<!ELEMENT schematic (description?, libraries?, attributes?, variantdefs?, classes?, modules?, groups?, parts?, sheets?, errors?)>
+<!ATTLIST schematic
+          xreflabel     %String;       #IMPLIED
+          xrefpart      %String;       #IMPLIED
+          >
+
+<!ELEMENT filter EMPTY>
+<!ATTLIST filter
+          name          %String;       #REQUIRED
+          expression    %String;       #REQUIRED
+          >
+
+<!ELEMENT module (description?, ports?, variantdefs?, groups?, parts?, sheets?)>
+<!ATTLIST module
+          name          %String;       #REQUIRED
+          prefix        %String;       ""
+          dx            %Coord;        #REQUIRED
+          dy            %Coord;        #REQUIRED
+          >
+
+<!ELEMENT board (description?, fusionsync?, fusionteam?, plain?, libraries?, attributes?, variantdefs?, classes?, designrules?, autorouter?, groups?, elements?, signals?, mfgpreviewcolors?, errors?)>
+<!ATTLIST board
+          limitedwidth  %Dimension;    #IMPLIED
+          >
+
+<!-- ### High level objects ############################################### -->
+
+<!ELEMENT sheet (description?, plain?, moduleinsts?, instances?, busses?, nets?)>
+
+<!ELEMENT package (description?, (polygon | wire | text | dimension | circle | rectangle | frame | hole | pad | smd)*)>
+<!ATTLIST package
+          name          %String;       #REQUIRED
+          urn              %Urn;       ""
+          locally_modified %Bool;      "no"
+          library_version  %Int;       ""
+          library_locally_modified %Bool; "no"
+          >
+          <!-- library_version and library_locally_modified: Only in managed libraries inside boards or schematics -->
+
+<!ELEMENT package3d (description?, packageinstances?)>
+<!ATTLIST package3d
+          name          %String;       ""
+          urn              %Urn;       #REQUIRED
+          type   %Package3dType;       #REQUIRED
+          library_version  %Int;       ""
+          library_locally_modified %Bool; "no"
+          >
+          <!-- library_version and library_locally_modified: Only in managed libraries inside boards or schematics -->
+
+<!ELEMENT symbol (description?, (polygon | wire | text | dimension | pin | circle | rectangle | frame)*)>
+<!ATTLIST symbol
+          name          %String;       #REQUIRED
+          urn              %Urn;       ""
+          locally_modified %Bool;      "no"
+          library_version  %Int;       ""
+          library_locally_modified %Bool; "no"
+          >
+          <!-- library_version and library_locally_modified: Only in managed libraries inside boards or schematics -->
+
+<!ELEMENT deviceset (description?, gates, devices, spice?)>
+<!ATTLIST deviceset
+          name          %String;       #REQUIRED
+          urn              %Urn;       ""
+          locally_modified %Bool;      "no"
+          prefix        %String;       ""
+          uservalue     %Bool;         "no"
+          library_version  %Int;       ""
+          library_locally_modified %Bool; "no"
+          >
+          <!-- library_version and library_locally_modified: Only in managed libraries inside boards or schematics -->
+
+<!ELEMENT device (connects?, package3dinstances?, technologies?)>
+<!ATTLIST device
+          name          %String;       ""
+          package       %String;       #IMPLIED
+          >
+
+<!ELEMENT bus (segment)*>
+<!ATTLIST bus
+          name          %String;       #REQUIRED
+          >
+
+<!ELEMENT net (segment)*>
+<!ATTLIST net
+          name          %String;       #REQUIRED
+          class         %Class;        "0"
+          >
+
+<!ELEMENT segment (pinref | portref | wire | junction | label | probe)*>
+          <!-- 'pinref' and 'junction' are only valid in a <net> context -->
+
+<!ELEMENT signal (contactref | polygon | wire | via)*>
+<!ATTLIST signal
+          name          %String;       #REQUIRED
+          class         %Class;        "0"
+          airwireshidden %Bool;        "no"
+          >
+<!ELEMENT mfgpreviewcolor EMPTY>
+<!ATTLIST mfgpreviewcolor
+          name          %String;       #REQUIRED
+          color         %String;       #REQUIRED
+          >
+
+<!-- ### Basic objects #################################################### -->
+
+<!ELEMENT moduleinst (attribute)*>
+<!ATTLIST moduleinst
+          name          %String;       #REQUIRED
+          module        %String;       #REQUIRED
+          modulevariant %String;       ""
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          offset        %Int;          "0"
+          smashed       %Bool;         "no"
+          rot           %Rotation;     "R0"
+          >
+          <!-- rot: Only 0, 90, 180 or 270 -->
+
+<!ELEMENT spice (pinmapping, model)>
+
+<!ELEMENT pinmapping (pinmap+)>
+<!ATTLIST pinmapping
+          isusermap     %Bool;         "no"
+          iddevicewide  %Bool;         "yes"
+          spiceprefix   %String;       ""
+          >
+
+<!ELEMENT pinmap EMPTY>
+<!ATTLIST pinmap
+          gate          %String;       #REQUIRED
+          pin           %String;       #REQUIRED
+          pinorder      %String;       #REQUIRED
+          >
+
+<!ELEMENT model (#PCDATA)>
+<!ATTLIST model
+          name          %String;       #REQUIRED
+          >
+
+<!ELEMENT variantdef EMPTY>
+<!ATTLIST variantdef
+          name          %String;       #REQUIRED
+          current       %Bool;         "no"
+          >
+
+<!ELEMENT variant EMPTY>
+<!ATTLIST variant
+          name          %String;       #REQUIRED
+          populate      %Bool;         "yes"
+          value         %String;       #IMPLIED
+          technology    %String;       #IMPLIED
+          >
+          <!-- technology: Only in part context -->
+
+<!ELEMENT gate EMPTY>
+<!ATTLIST gate
+          name          %String;       #REQUIRED
+          symbol        %String;       #REQUIRED
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          addlevel      %GateAddLevel; "next"
+          swaplevel     %Int;          "0"
+          >
+
+<!ELEMENT wire EMPTY>
+<!ATTLIST wire
+          x1            %Coord;        #REQUIRED
+          y1            %Coord;        #REQUIRED
+          x2            %Coord;        #REQUIRED
+          y2            %Coord;        #REQUIRED
+          width         %Dimension;    #REQUIRED
+          layer         %Layer;        #REQUIRED
+          extent        %Extent;       #IMPLIED
+          style         %WireStyle;    "continuous"
+          curve         %WireCurve;    "0"
+          cap           %WireCap;      "round"
+          grouprefs     IDREFS         #IMPLIED
+          >
+          <!-- extent: Only applicable for airwires -->
+          <!-- cap   : Only applicable if 'curve' is not zero -->
+
+<!ELEMENT dimension EMPTY>
+<!ATTLIST dimension
+          x1            %Coord;        #REQUIRED
+          y1            %Coord;        #REQUIRED
+          x2            %Coord;        #REQUIRED
+          y2            %Coord;        #REQUIRED
+          x3            %Coord;        #REQUIRED
+          y3            %Coord;        #REQUIRED
+          layer         %Layer;        #REQUIRED
+          dtype         %DimensionType; "parallel"
+          width         %Dimension;    "0.13"
+          extwidth      %Dimension;    "0"
+          extlength     %Dimension;    "0"
+          extoffset     %Dimension;    "0"
+          textsize      %Dimension;    #REQUIRED
+          textratio     %Int;          "8"
+          unit          %GridUnit;     "mm"
+          precision     %Int;          "2"
+          visible       %Bool;         "no"
+          grouprefs     IDREFS         #IMPLIED
+          >
+
+<!ELEMENT text (#PCDATA)>
+<!ATTLIST text
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          size          %Dimension;    #REQUIRED
+          layer         %Layer;        #REQUIRED
+          font          %TextFont;     "proportional"
+          ratio         %Int;          "8"
+          rot           %Rotation;     "R0"
+          align         %Align;        "bottom-left"
+          distance      %Int;          "50"
+          grouprefs     IDREFS         #IMPLIED
+          >
+
+<!ELEMENT circle EMPTY>
+<!ATTLIST circle
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          radius        %Coord;        #REQUIRED
+          width         %Dimension;    #REQUIRED
+          layer         %Layer;        #REQUIRED
+          grouprefs     IDREFS         #IMPLIED
+          >
+
+<!ELEMENT spline (vertex)*>
+<!-- Four simple (non-curve) vertices define the control points of a degree-3 spline curve -->
+<!ATTLIST spline
+          width          %Dimension;    #REQUIRED
+          >
+
+<!ELEMENT rectangle EMPTY>
+<!ATTLIST rectangle
+          x1            %Coord;        #REQUIRED
+          y1            %Coord;        #REQUIRED
+          x2            %Coord;        #REQUIRED
+          y2            %Coord;        #REQUIRED
+          layer         %Layer;        #REQUIRED
+          rot           %Rotation;     "R0"
+          grouprefs     IDREFS         #IMPLIED
+          >
+
+<!ELEMENT frame EMPTY>
+<!ATTLIST frame
+          x1            %Coord;       #REQUIRED
+          y1            %Coord;       #REQUIRED
+          x2            %Coord;       #REQUIRED
+          y2            %Coord;       #REQUIRED
+          columns       %Int;         #REQUIRED
+          rows          %Int;         #REQUIRED
+          layer         %Layer;       #REQUIRED
+          border-left   %Bool;        "yes"
+          border-top    %Bool;        "yes"
+          border-right  %Bool;        "yes"
+          border-bottom %Bool;        "yes"
+          grouprefs     IDREFS         #IMPLIED
+          >
+
+<!ELEMENT hole EMPTY>
+<!ATTLIST hole
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          drill         %Dimension;    #REQUIRED
+          grouprefs     IDREFS         #IMPLIED
+          >
+
+<!ELEMENT pad EMPTY>
+<!ATTLIST pad
+          name          %String;       #REQUIRED
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          drill         %Dimension;    #REQUIRED
+          diameter      %Dimension;    "0"
+          shape         %PadShape;     "round"
+          rot           %Rotation;     "R0"
+          stop          %Bool;         "yes"
+          thermals      %Bool;         "yes"
+          first         %Bool;         "no"
+          >
+
+<!ELEMENT smd EMPTY>
+<!ATTLIST smd
+          name          %String;       #REQUIRED
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          dx            %Dimension;    #REQUIRED
+          dy            %Dimension;    #REQUIRED
+          layer         %Layer;        #REQUIRED
+          roundness     %Int;          "0"
+          rot           %Rotation;     "R0"
+          stop          %Bool;         "yes"
+          thermals      %Bool;         "yes"
+          cream         %Bool;         "yes"
+          >
+
+<!ELEMENT element (attribute*, variant*)>
+          <!-- variant* is accepted only for compatibility with EAGLE 6.x files -->
+<!ATTLIST element
+          name          %String;       #REQUIRED
+          library       %String;       #REQUIRED
+          library_urn   %Urn;          ""
+          package       %String;       #REQUIRED
+          package3d_urn %Urn;          ""
+          override_package3d_urn %Urn; ""
+          override_package_urn %Urn;    ""
+          override_locally_modified %Bool; "no"
+          value         %String;       #REQUIRED
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          locked        %Bool;         "no"
+          populate      %Bool;         "yes"
+          smashed       %Bool;         "no"
+          rot           %Rotation;     "R0"
+          grouprefs     IDREFS         #IMPLIED
+          >
+          <!-- library_urn: Only in parts from online libraries -->
+
+<!ELEMENT board_group (attribute*, description?)>
+<!ATTLIST board_group
+          name              ID             #REQUIRED
+          selectable        %Bool;         #IMPLIED
+          grouprefs         IDREFS         #IMPLIED
+          >
+
+<!ELEMENT via EMPTY>
+<!ATTLIST via
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          extent        %Extent;       #REQUIRED
+          drill         %Dimension;    #REQUIRED
+          diameter      %Dimension;    "0"
+          shape         %ViaShape;     "round"
+          alwaysstop    %Bool;         "no"
+          grouprefs     IDREFS         #IMPLIED
+          >
+
+<!ELEMENT polygon (vertex)*>
+          <!-- the vertices must define a valid polygon; if the last vertex is the same as the first one, it is ignored -->
+<!ATTLIST polygon
+          width         %Dimension;    #REQUIRED
+          layer         %Layer;        #REQUIRED
+          spacing       %Dimension;    #IMPLIED
+          pour          %PolygonPour;  "solid"
+          isolate       %Dimension;    #IMPLIED
+          orphans       %Bool;         "no"
+          thermals      %Bool;         "yes"
+          rank          %Int;          "0"
+          grouprefs     IDREFS         #IMPLIED
+          >
+          <!-- isolate: Only in <signal> or <package> context -->
+          <!-- orphans: Only in <signal> context -->
+          <!-- thermals:Only in <signal> context -->
+          <!-- rank:    1..6 in <signal> context, 0 or 7 in <package> context -->
+
+<!ELEMENT vertex EMPTY>
+<!ATTLIST vertex
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          curve         %WireCurve;    "0"
+          >
+          <!-- curve: The curvature from this vertex to the next one -->
+
+<!ELEMENT pin EMPTY>
+<!ATTLIST pin
+          name          %String;       #REQUIRED
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          visible       %PinVisible;   "both"
+          length        %PinLength;    "long"
+          direction     %PinDirection; "io"
+          function      %PinFunction;  "none"
+          swaplevel     %Int;          "0"
+          rot           %Rotation;     "R0"
+          >
+
+<!ELEMENT part (attribute*, variant*, spice?)>
+<!ATTLIST part
+          name          %String;       #REQUIRED
+          library       %String;       #REQUIRED
+          library_urn   %Urn;          ""
+          deviceset     %String;       #REQUIRED
+          device        %String;       #REQUIRED
+          package3d_urn %Urn;          ""
+          override_package3d_urn %Urn; ""
+          override_package_urn %Urn;    ""
+          override_locally_modified %Bool; "no"
+          technology    %String;       ""
+          value         %String;       #IMPLIED
+          >
+          <!-- library_urn: Only in parts from online libraries -->
+
+<!ELEMENT port EMPTY>
+<!ATTLIST port
+          name          %String;       #REQUIRED
+          side          %Int;          #REQUIRED
+          coord         %Coord;        #REQUIRED
+          direction     %PortDirection; "io"
+          >
+
+<!ELEMENT instance (attribute)*>
+<!ATTLIST instance
+          part          %String;       #REQUIRED
+          gate          %String;       #REQUIRED
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          smashed       %Bool;         "no"
+          rot           %Rotation;     "R0"
+          grouprefs     IDREFS         #IMPLIED
+          >
+          <!-- rot: Only 0, 90, 180 or 270 -->
+
+<!ELEMENT label EMPTY>
+<!ATTLIST label
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          size          %Dimension;    #REQUIRED
+          layer         %Layer;        #REQUIRED
+          font          %TextFont;     "proportional"
+          ratio         %Int;          "8"
+          rot           %Rotation;     "R0"
+          xref          %Bool;         "no"
+          align         %Align;        "bottom-left"
+          grouprefs     IDREFS         #IMPLIED
+          >
+          <!-- rot:  Only 0, 90, 180 or 270 -->
+          <!-- xref: Only in <net> context -->
+
+<!ELEMENT probe EMPTY>
+<!ATTLIST probe
+        x             %Coord;        #REQUIRED
+        y             %Coord;        #REQUIRED
+        size          %Dimension;    #REQUIRED
+        layer         %Layer;        #REQUIRED
+        font          %TextFont;     "proportional"
+        ratio         %Int;          "8"
+        rot           %Rotation;     "R0"
+        xref          %Bool;         "no"
+        grouprefs     IDREFS         #IMPLIED
+        >
+        <!-- rot:  Only 0, 90, 180 or 270 -->
+        <!-- xref: Only in <net> context -->
+
+<!ELEMENT junction EMPTY>
+<!ATTLIST junction
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          grouprefs     IDREFS         #IMPLIED
+          >
+
+<!ELEMENT connect EMPTY>
+<!ATTLIST connect
+          gate          %String;       #REQUIRED
+          pin           %String;       #REQUIRED
+          pad           %String;       #REQUIRED
+          route         %ContactRoute; "all"
+          >
+
+<!ELEMENT packageinstance EMPTY>
+<!ATTLIST packageinstance
+          name          %String;       #REQUIRED
+          >
+
+<!ELEMENT package3dinstance EMPTY>
+<!ATTLIST package3dinstance
+          package3d_urn %Urn;          #REQUIRED
+          >
+
+<!ELEMENT technology (attribute)*>
+<!ATTLIST technology
+          name          %String;       #REQUIRED
+          >
+
+<!ELEMENT attribute EMPTY>
+<!ATTLIST attribute
+          name          %String;       #REQUIRED
+          value         %String;       #IMPLIED
+          x             %Coord;        #IMPLIED
+          y             %Coord;        #IMPLIED
+          size          %Dimension;    #IMPLIED
+          layer         %Layer;        #IMPLIED
+          font          %TextFont;     #IMPLIED
+          ratio         %Int;          #IMPLIED
+          rot           %Rotation;     "R0"
+          display       %AttributeDisplay; "value"
+          constant      %Bool;         "no"
+          align         %Align;        "bottom-left"
+          grouprefs     IDREFS         #IMPLIED
+          >
+          <!-- display: Only in <element> or <instance> context -->
+          <!-- constant:Only in <device> context -->
+
+<!ELEMENT pinref EMPTY>
+<!ATTLIST pinref
+          part          %String;       #REQUIRED
+          gate          %String;       #REQUIRED
+          pin           %String;       #REQUIRED
+          >
+
+<!ELEMENT contactref EMPTY>
+<!ATTLIST contactref
+          element       %String;       #REQUIRED
+          pad           %String;       #REQUIRED
+          route         %ContactRoute; "all"
+          routetag      %String;       ""
+          >
+
+<!ELEMENT portref EMPTY>
+<!ATTLIST portref
+          moduleinst    %String;       #REQUIRED
+          port          %String;       #REQUIRED
+          >
+
+<!ELEMENT schematic_group (attribute*, description?)>
+<!ATTLIST schematic_group
+          name              ID             #REQUIRED
+          selectable        %Bool;         #IMPLIED
+          width             %Dimension;    #IMPLIED
+          titleSize         %Dimension;    #IMPLIED
+          titleFont         %TextFont;     #IMPLIED
+          style             %WireStyle;    #IMPLIED
+          showAnnotations   %Bool;         #IMPLIED
+          layer             %Layer;        #IMPLIED
+          grouprefs         IDREFS         #IMPLIED
+          >
+
+<!-- ### Object lists ##################################################### -->
+
+<!ELEMENT variantdefs (variantdef)*>
+<!ELEMENT settings (setting)*>
+<!ELEMENT filters (filter)*>
+<!ELEMENT modules (module)*>
+<!ELEMENT moduleinsts (moduleinst)*>
+<!ELEMENT ports (port)*>
+<!ELEMENT sheets (sheet)*>
+<!ELEMENT layers (layer)*>
+<!ELEMENT packages (package)*>
+<!ELEMENT packages3d (package3d)*>
+<!ELEMENT symbols (symbol)*>
+<!ELEMENT devicesets (deviceset)*>
+<!ELEMENT gates (gate)*>
+<!ELEMENT devices (device)*>
+<!ELEMENT libraries (library)*>
+<!ELEMENT connects (connect)*>
+<!ELEMENT packageinstances (packageinstance)*>
+<!ELEMENT package3dinstances (package3dinstance)*>
+<!ELEMENT technologies (technology)*>
+<!ELEMENT attributes (attribute)*>
+<!ELEMENT classes (class)*>
+<!ELEMENT parts (part)*>
+<!ELEMENT instances (instance)*>
+<!ELEMENT errors (approved)*>
+<!ELEMENT plain (polygon | wire | text | dimension | circle | spline | rectangle | frame | hole)*>
+<!ELEMENT autorouter (pass)*>
+<!ELEMENT elements (element)*>
+<!ELEMENT signals (signal)*>
+<!ELEMENT mfgpreviewcolors (mfgpreviewcolor)*>
+<!ELEMENT busses (bus)*>
+<!ELEMENT nets (net)*>
+<!ELEMENT groups (schematic_group*, board_group*)>
+
+<!-- ### Miscellaneous objects ############################################ -->
+
+<!ELEMENT setting EMPTY>
+<!ATTLIST setting
+          alwaysvectorfont %Bool;         #IMPLIED
+          verticaltext     %VerticalText; "up"
+          keepoldvectorfont %Bool;        "no"          
+          >
+
+<!ELEMENT designrules (description*, param*)>
+<!ATTLIST designrules
+          name          %String;       #REQUIRED
+          >
+
+<!ELEMENT grid EMPTY>
+<!ATTLIST grid
+          distance      %Real;         #IMPLIED
+          unitdist      %GridUnit;     #IMPLIED
+          unit          %GridUnit;     #IMPLIED
+          style         %GridStyle;    "lines"
+          multiple      %Int;          "1"
+          display       %Bool;         "no"
+          altdistance   %Real;         #IMPLIED
+          altunitdist   %GridUnit;     #IMPLIED
+          altunit       %GridUnit;     #IMPLIED
+          >
+
+<!ELEMENT layer EMPTY>
+<!ATTLIST layer
+          number        %Layer;        #REQUIRED
+          name          %String;       #REQUIRED
+          color         %Int;          #REQUIRED
+          fill          %Int;          #REQUIRED
+          visible       %Bool;         "yes"
+          active        %Bool;         "yes"
+          >
+
+<!ELEMENT class (clearance)*>
+<!ATTLIST class
+          number        %Class;        #REQUIRED
+          name          %String;       #REQUIRED
+          width         %Dimension;    "0"
+          drill         %Dimension;    "0"
+          >
+
+<!ELEMENT clearance EMPTY>
+<!ATTLIST clearance
+          class         %Class;        #REQUIRED
+          value         %Dimension;    "0"
+          >
+
+<!ELEMENT description (#PCDATA)>
+<!ATTLIST description
+          language      %String;       "en"
+          >
+
+<!ELEMENT param EMPTY>
+<!ATTLIST param
+          name          %String;       #REQUIRED
+          value         %String;       #REQUIRED
+          >
+
+<!ELEMENT pass (param)*>
+<!ATTLIST pass
+          name          %String;       #REQUIRED
+          refer         %String;       #IMPLIED
+          active        %Bool;         "yes"
+          >
+
+<!ELEMENT approved EMPTY>
+<!ATTLIST approved
+          hash          %String;       #REQUIRED
+          >
+
+<!ELEMENT fusionsync EMPTY>
+<!ATTLIST fusionsync
+          huburn                   %String;       #REQUIRED
+          projecturn               %String;       #REQUIRED
+          f3durn                   %String;       #REQUIRED
+          pcbguid                  %String;       #REQUIRED
+          lastsyncedchangeguid     %String;       #REQUIRED
+          lastpulledtime           %String;       #REQUIRED
+          >
+		  
+<!ELEMENT fusionteam EMPTY>
+<!ATTLIST fusionteam
+          huburn                   %String;       #REQUIRED
+          projecturn               %String;       #REQUIRED
+          folderUrn                %String;       #REQUIRED
+          urn                      %String;       #REQUIRED
+          versionUrn               %String;       #REQUIRED
+          camFileUrn               %String;       #REQUIRED
+          camFileVersionUrn        %String;       #REQUIRED
+          lastpublishedchangeguid  %String;       #REQUIRED
+          >		  

--- a/Swoop/eagle-9.6.2.patched.dtd
+++ b/Swoop/eagle-9.6.2.patched.dtd
@@ -1,0 +1,742 @@
+<!--
+  EAGLE version $__VersionNumber__ DTD
+  Copyright (c) $__ThisYear__ Autodesk
+  http://www.autodesk.com
+
+  This file describes the XML file format used by EAGLE version $__VersionNumber__,
+  hereafter referred to as the "EAGLE File Format".
+  It is made available under the creative commons "CC BY-ND 3.0" license
+  (see http://creativecommons.org/licenses/by-nd/3.0).
+  You may use this file to implement a program that reads and/or writes files
+  in the EAGLE File Format. If your program writes files in the EAGLE File
+  Format, these files must be readable by EAGLE version $__VersionNumber__
+  without any error messages or warnings.
+-->
+
+<!-- ### Entity definitions ############################################### -->
+
+<!ENTITY % Int               "CDATA"> <!-- an integer number -->
+<!ENTITY % Real              "CDATA"> <!-- a real number -->
+<!ENTITY % String            "CDATA"> <!-- a character string -->
+<!ENTITY % Bool              "(no | yes)">
+<!ENTITY % Coord             "%Real;"> <!-- coordinates, given in millimeters -->
+<!ENTITY % Dimension         "%Real;"> <!-- dimensions, given in millimeters -->
+<!ENTITY % Layer             "%Int;"> <!-- layer number -->
+<!ENTITY % GridUnit          "(mic | mm | mil | inch)">
+<!ENTITY % GridStyle         "(lines | dots)">
+<!ENTITY % WireStyle         "(continuous | longdash | shortdash | dashdot)">
+<!ENTITY % WireCap           "(flat | round)">
+<!ENTITY % WireCurve         "%Real;"> <!-- curvature of a wire; allowed range: -359.9..359.9 -->
+<!ENTITY % Class             "%Int;"> <!-- net class -->
+<!ENTITY % PadShape          "(square | round | octagon | long | offset)">
+<!ENTITY % ViaShape          "(square | round | octagon)">
+<!ENTITY % TextFont          "(vector | proportional | fixed)">
+<!ENTITY % Rotation          "CDATA"> <!-- rotation of an object; allowed range: [MSR]0..359.9 -->
+<!ENTITY % AttributeDisplay  "(off | value | name | both)">
+<!ENTITY % Extent            "%String;"> <!-- the layers a via or airwire extends through, given as "topmost-bottommost" -->
+<!ENTITY % PolygonPour       "(solid | hatch | cutout)">
+<!ENTITY % PinVisible        "(off | pad | pin | both)">
+<!ENTITY % PinLength         "(point | short | middle | long)">
+<!ENTITY % PinDirection      "(nc | in | out | io | oc | pwr | pas | hiz | sup)">
+<!ENTITY % PinFunction       "(none | dot | clk | dotclk)">
+<!ENTITY % PortDirection     "(nc | in | out | io | oc | pwr | pas | hiz)">
+<!ENTITY % GateAddLevel      "(must | can | next | request | always)">
+<!ENTITY % ContactRoute      "(all | any)">
+<!ENTITY % DimensionType     "(parallel | horizontal | vertical | radius | diameter | angle | leader)">
+<!ENTITY % Package3dType     "(model | box)">
+<!ENTITY % Severity          "(info | warning | error)">
+<!ENTITY % Align             "(bottom-left | bottom-center | bottom-right | center-left | center | center-right | top-left | top-center | top-right)">
+<!ENTITY % VerticalText      "(up | down)">
+<!ENTITY % Urn               "%String;"> <!-- of the form "urn:adsk.eagle:<ASSET_TYPE>:<ASSET_ID>/<VERSION>", where:
+                                              - <ASSET_TYPE> is "symbol", "footprint", "package", "component", or "library"
+                                              - <ASSET_ID> is an integer
+                                              - <VERSION> is an integer
+                                              The "/<VERSION>" is omitted when referencing the asset without specifying a particular version.
+                                              For example, "urn:adsk.eagle:component:60986/2" references version 2 of component 60986 and
+                                              "urn:adsk.eagle:library:60968" references library 60986 without specifying a version. -->
+
+<!-- ### Drawing definitions ############################################## -->
+
+<!ELEMENT eagle (compatibility?, drawing, compatibility?)>
+<!ATTLIST eagle
+          version       %Real;         #REQUIRED
+          >
+          <!-- version: The EAGLE program version that generated this file, in the form V.RR -->
+
+<!ELEMENT compatibility (note)*>
+
+<!ELEMENT note (#PCDATA)>
+<!ATTLIST note
+          version       %Real;         #REQUIRED
+          severity      %Severity;     #REQUIRED
+          minversion    %String;       ""
+          >
+          <!-- version: The EAGLE program version that introduced this compatibility note -->
+
+<!ELEMENT drawing (settings?, grid?, filters?, layers, (library | schematic | board))>
+
+<!ELEMENT library (description?, packages?, packages3d?, symbols?, devicesets?)>
+<!ATTLIST library
+          name          %String;       ""
+          urn           %Urn;          ""
+          >
+          <!-- name: Only in libraries used inside boards or schematics -->
+          <!-- urn: Only in online libraries used inside boards or schematics -->
+
+<!ELEMENT schematic (description?, libraries?, attributes?, variantdefs?, classes?, modules?, groups?, parts?, sheets?, errors?)>
+<!ATTLIST schematic
+          xreflabel     %String;       #IMPLIED
+          xrefpart      %String;       #IMPLIED
+          >
+
+<!ELEMENT filter EMPTY>
+<!ATTLIST filter
+          name          %String;       #REQUIRED
+          expression    %String;       #REQUIRED
+          >
+
+<!ELEMENT module (description?, ports?, variantdefs?, groups?, parts?, sheets?)>
+<!ATTLIST module
+          name          %String;       #REQUIRED
+          prefix        %String;       ""
+          dx            %Coord;        #REQUIRED
+          dy            %Coord;        #REQUIRED
+          >
+
+<!ELEMENT board (description?, fusionsync?, fusionteam?, plain?, libraries?, attributes?, variantdefs?, classes?, designrules?, autorouter?, groups?, elements?, signals?, mfgpreviewcolors?, errors?)>
+<!ATTLIST board
+          limitedwidth  %Dimension;    #IMPLIED
+          >
+
+<!-- ### High level objects ############################################### -->
+
+<!ELEMENT sheet (description?, plain?, moduleinsts?, instances?, busses?, nets?)>
+
+<!ELEMENT package (description?, (polygon | wire | text | dimension | circle | rectangle | frame | hole | pad | smd)*)>
+<!ATTLIST package
+          name          %String;       #REQUIRED
+          urn              %Urn;       ""
+          locally_modified %Bool;      "no"
+          library_version  %Int;       ""
+          library_locally_modified %Bool; "no"
+          >
+          <!-- library_version and library_locally_modified: Only in managed libraries inside boards or schematics -->
+
+<!ELEMENT package3d (description?, packageinstances?)>
+<!ATTLIST package3d
+          name          %String;       ""
+          urn              %Urn;       #REQUIRED
+          type   %Package3dType;       #REQUIRED
+          library_version  %Int;       ""
+          library_locally_modified %Bool; "no"
+          >
+          <!-- library_version and library_locally_modified: Only in managed libraries inside boards or schematics -->
+
+<!ELEMENT symbol (description?, (polygon | wire | text | dimension | pin | circle | rectangle | frame)*)>
+<!ATTLIST symbol
+          name          %String;       #REQUIRED
+          urn              %Urn;       ""
+          locally_modified %Bool;      "no"
+          library_version  %Int;       ""
+          library_locally_modified %Bool; "no"
+          >
+          <!-- library_version and library_locally_modified: Only in managed libraries inside boards or schematics -->
+
+<!ELEMENT deviceset (description?, gates, devices, spice?)>
+<!ATTLIST deviceset
+          name          %String;       #REQUIRED
+          urn              %Urn;       ""
+          locally_modified %Bool;      "no"
+          prefix        %String;       ""
+          uservalue     %Bool;         "no"
+          library_version  %Int;       ""
+          library_locally_modified %Bool; "no"
+          >
+          <!-- library_version and library_locally_modified: Only in managed libraries inside boards or schematics -->
+
+<!ELEMENT device (connects?, package3dinstances?, technologies?)>
+<!ATTLIST device
+          name          %String;       ""
+          package       %String;       #IMPLIED
+          >
+
+<!ELEMENT bus (segment)*>
+<!ATTLIST bus
+          name          %String;       #REQUIRED
+          >
+
+<!ELEMENT net (segment)*>
+<!ATTLIST net
+          name          %String;       #REQUIRED
+          class         %Class;        "0"
+          >
+
+<!ELEMENT segment (pinref | portref | wire | junction | label | probe)*>
+          <!-- 'pinref' and 'junction' are only valid in a <net> context -->
+
+<!ELEMENT signal (contactref | polygon | wire | via)*>
+<!ATTLIST signal
+          name          %String;       #REQUIRED
+          class         %Class;        "0"
+          airwireshidden %Bool;        "no"
+          >
+<!ELEMENT mfgpreviewcolor EMPTY>
+<!ATTLIST mfgpreviewcolor
+          name          %String;       #REQUIRED
+          color         %String;       #REQUIRED
+          >
+
+<!-- ### Basic objects #################################################### -->
+
+<!ELEMENT moduleinst (attribute)*>
+<!ATTLIST moduleinst
+          name          %String;       #REQUIRED
+          module        %String;       #REQUIRED
+          modulevariant %String;       ""
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          offset        %Int;          "0"
+          smashed       %Bool;         "no"
+          rot           %Rotation;     "R0"
+          >
+          <!-- rot: Only 0, 90, 180 or 270 -->
+
+<!ELEMENT spice (pinmapping, model)>
+
+<!ELEMENT pinmapping (pinmap+)>
+<!ATTLIST pinmapping
+          isusermap     %Bool;         "no"
+          iddevicewide  %Bool;         "yes"
+          spiceprefix   %String;       ""
+          >
+
+<!ELEMENT pinmap EMPTY>
+<!ATTLIST pinmap
+          gate          %String;       #REQUIRED
+          pin           %String;       #REQUIRED
+          pinorder      %String;       #REQUIRED
+          >
+
+<!ELEMENT model (#PCDATA)>
+<!ATTLIST model
+          name          %String;       #REQUIRED
+          >
+
+<!ELEMENT variantdef EMPTY>
+<!ATTLIST variantdef
+          name          %String;       #REQUIRED
+          current       %Bool;         "no"
+          >
+
+<!ELEMENT variant EMPTY>
+<!ATTLIST variant
+          name          %String;       #REQUIRED
+          populate      %Bool;         "yes"
+          value         %String;       #IMPLIED
+          technology    %String;       #IMPLIED
+          >
+          <!-- technology: Only in part context -->
+
+<!ELEMENT gate EMPTY>
+<!ATTLIST gate
+          name          %String;       #REQUIRED
+          symbol        %String;       #REQUIRED
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          addlevel      %GateAddLevel; "next"
+          swaplevel     %Int;          "0"
+          >
+
+<!ELEMENT wire EMPTY>
+<!ATTLIST wire
+          x1            %Coord;        #REQUIRED
+          y1            %Coord;        #REQUIRED
+          x2            %Coord;        #REQUIRED
+          y2            %Coord;        #REQUIRED
+          width         %Dimension;    #REQUIRED
+          layer         %Layer;        #REQUIRED
+          extent        %Extent;       #IMPLIED
+          style         %WireStyle;    "continuous"
+          curve         %WireCurve;    "0"
+          cap           %WireCap;      "round"
+          grouprefs     IDREFS         #IMPLIED
+          >
+          <!-- extent: Only applicable for airwires -->
+          <!-- cap   : Only applicable if 'curve' is not zero -->
+
+<!ELEMENT dimension EMPTY>
+<!ATTLIST dimension
+          x1            %Coord;        #REQUIRED
+          y1            %Coord;        #REQUIRED
+          x2            %Coord;        #REQUIRED
+          y2            %Coord;        #REQUIRED
+          x3            %Coord;        #REQUIRED
+          y3            %Coord;        #REQUIRED
+          layer         %Layer;        #REQUIRED
+          dtype         %DimensionType; "parallel"
+          width         %Dimension;    "0.13"
+          extwidth      %Dimension;    "0"
+          extlength     %Dimension;    "0"
+          extoffset     %Dimension;    "0"
+          textsize      %Dimension;    #REQUIRED
+          textratio     %Int;          "8"
+          unit          %GridUnit;     "mm"
+          precision     %Int;          "2"
+          visible       %Bool;         "no"
+          grouprefs     IDREFS         #IMPLIED
+          >
+
+<!ELEMENT text (#PCDATA)>
+<!ATTLIST text
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          size          %Dimension;    #REQUIRED
+          layer         %Layer;        #REQUIRED
+          font          %TextFont;     "proportional"
+          ratio         %Int;          "8"
+          rot           %Rotation;     "R0"
+          align         %Align;        "bottom-left"
+          distance      %Int;          "50"
+          grouprefs     IDREFS         #IMPLIED
+          >
+
+<!ELEMENT circle EMPTY>
+<!ATTLIST circle
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          radius        %Coord;        #REQUIRED
+          width         %Dimension;    #REQUIRED
+          layer         %Layer;        #REQUIRED
+          grouprefs     IDREFS         #IMPLIED
+          >
+
+<!ELEMENT spline (vertex)*>
+<!-- Four simple (non-curve) vertices define the control points of a degree-3 spline curve -->
+<!ATTLIST spline
+          width          %Dimension;    #REQUIRED
+          >
+
+<!ELEMENT rectangle EMPTY>
+<!ATTLIST rectangle
+          x1            %Coord;        #REQUIRED
+          y1            %Coord;        #REQUIRED
+          x2            %Coord;        #REQUIRED
+          y2            %Coord;        #REQUIRED
+          layer         %Layer;        #REQUIRED
+          rot           %Rotation;     "R0"
+          grouprefs     IDREFS         #IMPLIED
+          >
+
+<!ELEMENT frame EMPTY>
+<!ATTLIST frame
+          x1            %Coord;       #REQUIRED
+          y1            %Coord;       #REQUIRED
+          x2            %Coord;       #REQUIRED
+          y2            %Coord;       #REQUIRED
+          columns       %Int;         #REQUIRED
+          rows          %Int;         #REQUIRED
+          layer         %Layer;       #REQUIRED
+          border-left   %Bool;        "yes"
+          border-top    %Bool;        "yes"
+          border-right  %Bool;        "yes"
+          border-bottom %Bool;        "yes"
+          grouprefs     IDREFS         #IMPLIED
+          >
+
+<!ELEMENT hole EMPTY>
+<!ATTLIST hole
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          drill         %Dimension;    #REQUIRED
+          grouprefs     IDREFS         #IMPLIED
+          >
+
+<!ELEMENT pad EMPTY>
+<!ATTLIST pad
+          name          %String;       #REQUIRED
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          drill         %Dimension;    #REQUIRED
+          diameter      %Dimension;    "0"
+          shape         %PadShape;     "round"
+          rot           %Rotation;     "R0"
+          stop          %Bool;         "yes"
+          thermals      %Bool;         "yes"
+          first         %Bool;         "no"
+          >
+
+<!ELEMENT smd EMPTY>
+<!ATTLIST smd
+          name          %String;       #REQUIRED
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          dx            %Dimension;    #REQUIRED
+          dy            %Dimension;    #REQUIRED
+          layer         %Layer;        #REQUIRED
+          roundness     %Int;          "0"
+          rot           %Rotation;     "R0"
+          stop          %Bool;         "yes"
+          thermals      %Bool;         "yes"
+          cream         %Bool;         "yes"
+          >
+
+<!ELEMENT element (attribute*, variant*)>
+          <!-- variant* is accepted only for compatibility with EAGLE 6.x files -->
+<!ATTLIST element
+          name          %String;       #REQUIRED
+          library       %String;       #REQUIRED
+          library_urn   %Urn;          ""
+          package       %String;       #REQUIRED
+          package3d_urn %Urn;          ""
+          override_package3d_urn %Urn; ""
+          override_package_urn %Urn;    ""
+          override_locally_modified %Bool; "no"
+          value         %String;       #REQUIRED
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          locked        %Bool;         "no"
+          populate      %Bool;         "yes"
+          smashed       %Bool;         "no"
+          rot           %Rotation;     "R0"
+          grouprefs     IDREFS         #IMPLIED
+          >
+          <!-- library_urn: Only in parts from online libraries -->
+
+<!ELEMENT board_group (attribute*, description?)>
+<!ATTLIST board_group
+          name              ID             #REQUIRED
+          selectable        %Bool;         #IMPLIED
+          grouprefs         IDREFS         #IMPLIED
+          >
+
+<!ELEMENT via EMPTY>
+<!ATTLIST via
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          extent        %Extent;       #REQUIRED
+          drill         %Dimension;    #REQUIRED
+          diameter      %Dimension;    "0"
+          shape         %ViaShape;     "round"
+          alwaysstop    %Bool;         "no"
+          grouprefs     IDREFS         #IMPLIED
+          >
+
+<!ELEMENT polygon (vertex)*>
+          <!-- the vertices must define a valid polygon; if the last vertex is the same as the first one, it is ignored -->
+<!ATTLIST polygon
+          width         %Dimension;    #REQUIRED
+          layer         %Layer;        #REQUIRED
+          spacing       %Dimension;    #IMPLIED
+          pour          %PolygonPour;  "solid"
+          isolate       %Dimension;    #IMPLIED
+          orphans       %Bool;         "no"
+          thermals      %Bool;         "yes"
+          rank          %Int;          "0"
+          grouprefs     IDREFS         #IMPLIED
+          >
+          <!-- isolate: Only in <signal> or <package> context -->
+          <!-- orphans: Only in <signal> context -->
+          <!-- thermals:Only in <signal> context -->
+          <!-- rank:    1..6 in <signal> context, 0 or 7 in <package> context -->
+
+<!ELEMENT vertex EMPTY>
+<!ATTLIST vertex
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          curve         %WireCurve;    "0"
+          >
+          <!-- curve: The curvature from this vertex to the next one -->
+
+<!ELEMENT pin EMPTY>
+<!ATTLIST pin
+          name          %String;       #REQUIRED
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          visible       %PinVisible;   "both"
+          length        %PinLength;    "long"
+          direction     %PinDirection; "io"
+          function      %PinFunction;  "none"
+          swaplevel     %Int;          "0"
+          rot           %Rotation;     "R0"
+          >
+
+<!ELEMENT part (attribute*, variant*, spice?)>
+<!ATTLIST part
+          name          %String;       #REQUIRED
+          library       %String;       #REQUIRED
+          library_urn   %Urn;          ""
+          deviceset     %String;       #REQUIRED
+          device        %String;       #REQUIRED
+          package3d_urn %Urn;          ""
+          override_package3d_urn %Urn; ""
+          override_package_urn %Urn;    ""
+          override_locally_modified %Bool; "no"
+          technology    %String;       ""
+          value         %String;       #IMPLIED
+          >
+          <!-- library_urn: Only in parts from online libraries -->
+
+<!ELEMENT port EMPTY>
+<!ATTLIST port
+          name          %String;       #REQUIRED
+          side          %Int;          #REQUIRED
+          coord         %Coord;        #REQUIRED
+          direction     %PortDirection; "io"
+          >
+
+<!ELEMENT instance (attribute)*>
+<!ATTLIST instance
+          part          %String;       #REQUIRED
+          gate          %String;       #REQUIRED
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          smashed       %Bool;         "no"
+          rot           %Rotation;     "R0"
+          grouprefs     IDREFS         #IMPLIED
+          >
+          <!-- rot: Only 0, 90, 180 or 270 -->
+
+<!ELEMENT label EMPTY>
+<!ATTLIST label
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          size          %Dimension;    #REQUIRED
+          layer         %Layer;        #REQUIRED
+          font          %TextFont;     "proportional"
+          ratio         %Int;          "8"
+          rot           %Rotation;     "R0"
+          xref          %Bool;         "no"
+          align         %Align;        "bottom-left"
+          grouprefs     IDREFS         #IMPLIED
+          >
+          <!-- rot:  Only 0, 90, 180 or 270 -->
+          <!-- xref: Only in <net> context -->
+
+<!ELEMENT probe EMPTY>
+<!ATTLIST probe
+        x             %Coord;        #REQUIRED
+        y             %Coord;        #REQUIRED
+        size          %Dimension;    #REQUIRED
+        layer         %Layer;        #REQUIRED
+        font          %TextFont;     "proportional"
+        ratio         %Int;          "8"
+        rot           %Rotation;     "R0"
+        xref          %Bool;         "no"
+        grouprefs     IDREFS         #IMPLIED
+        >
+        <!-- rot:  Only 0, 90, 180 or 270 -->
+        <!-- xref: Only in <net> context -->
+
+<!ELEMENT junction EMPTY>
+<!ATTLIST junction
+          x             %Coord;        #REQUIRED
+          y             %Coord;        #REQUIRED
+          grouprefs     IDREFS         #IMPLIED
+          >
+
+<!ELEMENT connect EMPTY>
+<!ATTLIST connect
+          gate          %String;       #REQUIRED
+          pin           %String;       #REQUIRED
+          pad           %String;       #REQUIRED
+          route         %ContactRoute; "all"
+          >
+
+<!ELEMENT packageinstance EMPTY>
+<!ATTLIST packageinstance
+          name          %String;       #REQUIRED
+          >
+
+<!ELEMENT package3dinstance EMPTY>
+<!ATTLIST package3dinstance
+          package3d_urn %Urn;          #REQUIRED
+          >
+
+<!ELEMENT technology (attribute)*>
+<!ATTLIST technology
+          name          %String;       #REQUIRED
+          >
+
+<!ELEMENT attribute EMPTY>
+<!ATTLIST attribute
+          name          %String;       #REQUIRED
+          value         %String;       #IMPLIED
+          x             %Coord;        #IMPLIED
+          y             %Coord;        #IMPLIED
+          size          %Dimension;    #IMPLIED
+          layer         %Layer;        #IMPLIED
+          font          %TextFont;     #IMPLIED
+          ratio         %Int;          #IMPLIED
+          rot           %Rotation;     "R0"
+          display       %AttributeDisplay; "value"
+          constant      %Bool;         "no"
+          align         %Align;        "bottom-left"
+          grouprefs     IDREFS         #IMPLIED
+          >
+          <!-- display: Only in <element> or <instance> context -->
+          <!-- constant:Only in <device> context -->
+
+<!ELEMENT pinref EMPTY>
+<!ATTLIST pinref
+          part          %String;       #REQUIRED
+          gate          %String;       #REQUIRED
+          pin           %String;       #REQUIRED
+          >
+
+<!ELEMENT contactref EMPTY>
+<!ATTLIST contactref
+          element       %String;       #REQUIRED
+          pad           %String;       #REQUIRED
+          route         %ContactRoute; "all"
+          routetag      %String;       ""
+          >
+
+<!ELEMENT portref EMPTY>
+<!ATTLIST portref
+          moduleinst    %String;       #REQUIRED
+          port          %String;       #REQUIRED
+          >
+
+<!ELEMENT schematic_group (attribute*, description?)>
+<!ATTLIST schematic_group
+          name              ID             #REQUIRED
+          selectable        %Bool;         #IMPLIED
+          width             %Dimension;    #IMPLIED
+          titleSize         %Dimension;    #IMPLIED
+          titleFont         %TextFont;     #IMPLIED
+          style             %WireStyle;    #IMPLIED
+          showAnnotations   %Bool;         #IMPLIED
+          layer             %Layer;        #IMPLIED
+          grouprefs         IDREFS         #IMPLIED
+          >
+
+<!-- ### Object lists ##################################################### -->
+
+<!ELEMENT variantdefs (variantdef)*>
+<!ELEMENT settings (setting)*>
+<!ELEMENT filters (filter)*>
+<!ELEMENT modules (module)*>
+<!ELEMENT moduleinsts (moduleinst)*>
+<!ELEMENT ports (port)*>
+<!ELEMENT sheets (sheet)*>
+<!ELEMENT layers (layer)*>
+<!ELEMENT packages (package)*>
+<!ELEMENT packages3d (package3d)*>
+<!ELEMENT symbols (symbol)*>
+<!ELEMENT devicesets (deviceset)*>
+<!ELEMENT gates (gate)*>
+<!ELEMENT devices (device)*>
+<!ELEMENT libraries (library)*>
+<!ELEMENT connects (connect)*>
+<!ELEMENT packageinstances (packageinstance)*>
+<!ELEMENT package3dinstances (package3dinstance)*>
+<!ELEMENT technologies (technology)*>
+<!ELEMENT attributes (attribute)*>
+<!ELEMENT classes (class)*>
+<!ELEMENT parts (part)*>
+<!ELEMENT instances (instance)*>
+<!ELEMENT errors (approved)*>
+<!ELEMENT plain (polygon | wire | text | dimension | circle | spline | rectangle | frame | hole)*>
+<!ELEMENT autorouter (pass)*>
+<!ELEMENT elements (element)*>
+<!ELEMENT signals (signal)*>
+<!ELEMENT mfgpreviewcolors (mfgpreviewcolor)*>
+<!ELEMENT busses (bus)*>
+<!ELEMENT nets (net)*>
+<!ELEMENT groups (schematic_group*, board_group*)>
+
+<!-- ### Miscellaneous objects ############################################ -->
+
+<!ELEMENT setting EMPTY>
+<!ATTLIST setting
+          alwaysvectorfont %Bool;         #IMPLIED
+          verticaltext     %VerticalText; "up"
+          keepoldvectorfont %Bool;        "no"          
+          >
+
+<!ELEMENT designrules (description*, param*)>
+<!ATTLIST designrules
+          name          %String;       #REQUIRED
+          >
+
+<!ELEMENT grid EMPTY>
+<!ATTLIST grid
+          distance      %Real;         #IMPLIED
+          unitdist      %GridUnit;     #IMPLIED
+          unit          %GridUnit;     #IMPLIED
+          style         %GridStyle;    "lines"
+          multiple      %Int;          "1"
+          display       %Bool;         "no"
+          altdistance   %Real;         #IMPLIED
+          altunitdist   %GridUnit;     #IMPLIED
+          altunit       %GridUnit;     #IMPLIED
+          >
+
+<!ELEMENT layer EMPTY>
+<!ATTLIST layer
+          number        %Layer;        #REQUIRED
+          name          %String;       #REQUIRED
+          color         %Int;          #REQUIRED
+          fill          %Int;          #REQUIRED
+          visible       %Bool;         "yes"
+          active        %Bool;         "yes"
+          >
+
+<!ELEMENT class (clearance)*>
+<!ATTLIST class
+          number        %Class;        #REQUIRED
+          name          %String;       #REQUIRED
+          width         %Dimension;    "0"
+          drill         %Dimension;    "0"
+          >
+
+<!ELEMENT clearance EMPTY>
+<!ATTLIST clearance
+          class         %Class;        #REQUIRED
+          value         %Dimension;    "0"
+          >
+
+<!ELEMENT description (#PCDATA)>
+<!ATTLIST description
+          language      %String;       "en"
+          >
+
+<!ELEMENT param EMPTY>
+<!ATTLIST param
+          name          %String;       #REQUIRED
+          value         %String;       #REQUIRED
+          >
+
+<!ELEMENT pass (param)*>
+<!ATTLIST pass
+          name          %String;       #REQUIRED
+          refer         %String;       #IMPLIED
+          active        %Bool;         "yes"
+          >
+
+<!ELEMENT approved EMPTY>
+<!ATTLIST approved
+          hash          %String;       #REQUIRED
+          >
+
+<!ELEMENT fusionsync EMPTY>
+<!ATTLIST fusionsync
+          huburn                   %String;       #REQUIRED
+          projecturn               %String;       #REQUIRED
+          f3durn                   %String;       #REQUIRED
+          pcbguid                  %String;       #REQUIRED
+          lastsyncedchangeguid     %String;       #REQUIRED
+          lastpulledtime           %String;       #REQUIRED
+          >
+		  
+<!ELEMENT fusionteam EMPTY>
+<!ATTLIST fusionteam
+          huburn                   %String;       #REQUIRED
+          projecturn               %String;       #REQUIRED
+          folderUrn                %String;       #REQUIRED
+          urn                      %String;       #REQUIRED
+          versionUrn               %String;       #REQUIRED
+          camFileUrn               %String;       #REQUIRED
+          camFileVersionUrn        %String;       #REQUIRED
+          lastpublishedchangeguid  %String;       #REQUIRED
+          >		  


### PR DESCRIPTION
Since 9.2 DTD changes are:
 - Splines (and some shapes gain angle types)
 - Named groups
 - More 3D package stuff

The patch from 9.2.2 is preserved, but slightly reduced:
 - Dropped the fixed circle dimension
 - The 'locally_modified' key is part of the offical DTD now